### PR TITLE
Update to SDL2

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,1 +1,2 @@
-PKG_LIBS= -lGL -lGLU -lSDL -LSDmain
+PKG_CXXFLAGS = -I/usr/local/Cellar/sdl2/2.0.16/include/ -I/opt/X11/include
+PKG_LIBS= -framework OpenGL -framework GLUT -lSDL2

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // plotxyz
 void plotxyz(NumericVector x, NumericVector y, NumericVector z, IntegerVector r, IntegerVector g, IntegerVector b, IntegerVector id, float size);
 RcppExport SEXP _lidRviewer_plotxyz(SEXP xSEXP, SEXP ySEXP, SEXP zSEXP, SEXP rSEXP, SEXP gSEXP, SEXP bSEXP, SEXP idSEXP, SEXP sizeSEXP) {

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -131,7 +131,9 @@ void Camera::OnMouseMotion(const SDL_MouseMotionEvent & event)
   }
 }
 
-void Camera::OnMouseButton(const SDL_MouseButtonEvent & event)
+// void Camera::OnMouseButton(const SDL_MouseButtonEvent & event)
+void Camera::OnMouseEvent(const SDL_MouseButtonEvent & event, 
+                          const SDL_MouseWheelEvent & event_wheel)
 {
   if (event.button == SDL_BUTTON_LEFT)
   {
@@ -159,14 +161,14 @@ void Camera::OnMouseButton(const SDL_MouseButtonEvent & event)
       SDL_SetCursor(_move);
     }
   }
-  else if ((event.button == SDL_BUTTON_WHEELUP) && (event.type == SDL_MOUSEBUTTONDOWN))
+  else if((event_wheel.y > 0) && (event.type == SDL_MOUSEBUTTONDOWN))
   {
     distance -= zoomSensivity;
     panSensivity = distance*0.001;
     zoomSensivity = distance*0.05;
     changed = true;
   }
-  else if ((event.button == SDL_BUTTON_WHEELDOWN) && (event.type == SDL_MOUSEBUTTONDOWN))
+  else if((event_wheel.y < 0) && (event.type == SDL_MOUSEBUTTONDOWN))
   {
     distance += zoomSensivity;
     panSensivity = distance*0.001;

--- a/src/camera.h
+++ b/src/camera.h
@@ -1,7 +1,7 @@
 #ifndef CAMERA_H
 #define CAMERA_H
 
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 
 class Camera
 {
@@ -10,7 +10,8 @@ class Camera
     ~Camera();
 
     void OnMouseMotion(const SDL_MouseMotionEvent & event);
-    void OnMouseButton(const SDL_MouseButtonEvent & event);
+    void OnMouseEvent(const SDL_MouseButtonEvent & event, 
+                      const SDL_MouseWheelEvent & event_wheel);
     void OnKeyboard(const SDL_KeyboardEvent & event);
 
     void look();

--- a/src/drawer.cpp
+++ b/src/drawer.cpp
@@ -69,7 +69,6 @@ void Drawer::draw()
 
   glEnd();
   glFlush();
-  SDL_GL_SwapBuffers();
 
   camera->changed = false;
 

--- a/src/sdlapp.cpp
+++ b/src/sdlapp.cpp
@@ -18,8 +18,14 @@ void plotxyz(NumericVector x, NumericVector y, NumericVector z, IntegerVector r,
 
   SDL_Init(SDL_INIT_VIDEO);
 
-  SDL_WM_SetCaption("Point Cloud Viewer", NULL);
-  SDL_SetVideoMode(width, height, 32, SDL_OPENGL | SDL_RESIZABLE);
+  SDL_Window *window = SDL_CreateWindow(
+    "Point Cloud Viewer",
+    SDL_WINDOWPOS_CENTERED,
+    SDL_WINDOWPOS_CENTERED,
+    width, height,
+    SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE
+  );
+  SDL_GL_CreateContext(window);
 
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
@@ -60,12 +66,19 @@ void plotxyz(NumericVector x, NumericVector y, NumericVector z, IntegerVector r,
         break;
       case SDL_MOUSEBUTTONUP:
       case SDL_MOUSEBUTTONDOWN:
-        drawer->camera->OnMouseButton(event.button);
+        drawer->camera->OnMouseEvent(event.button, event.wheel);
         break;
-      case SDL_VIDEORESIZE:
-        width = event.resize.w;
-        height = event.resize.h;
-        SDL_SetVideoMode(width, height, 32, SDL_OPENGL| SDL_RESIZABLE);
+      case SDL_WINDOWEVENT_RESIZED:
+        width = event.window.data1;
+        height = event.window.data2;
+        SDL_Window *window = SDL_CreateWindow(
+          "Point Cloud Viewer",
+          SDL_WINDOWPOS_CENTERED,
+          SDL_WINDOWPOS_CENTERED,
+          width, height,
+          SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE
+        );
+        SDL_GL_CreateContext(window);
         glViewport(0, 0, width, height);
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
@@ -73,6 +86,7 @@ void plotxyz(NumericVector x, NumericVector y, NumericVector z, IntegerVector r,
         drawer->camera->changed = true;
         break;
       }
+      SDL_GL_SwapWindow(window);
     }
 
     current_time = SDL_GetTicks();

--- a/src/sdlglutils.cpp
+++ b/src/sdlglutils.cpp
@@ -1,5 +1,5 @@
 #include "sdlglutils.h"
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 #include <GL/glu.h>
 #include <cstring>
 #include <cstdlib>

--- a/src/sdlglutils.h
+++ b/src/sdlglutils.h
@@ -1,7 +1,7 @@
 #ifndef SDLGLUTILS_H
 #define SDLGLUTILS_H
 
-#include <SDL/SDL.h>
+#include <SDL2/SDL.h>
 
 #ifndef GL_CLAMP_TO_EDGE
 #define GL_CLAMP_TO_EDGE 0x812F


### PR DESCRIPTION
## Overview
This updates the relevant C++ code in `lidRviewer` to use the updated Simple DirectMedia Layer 2.0 (`SDL2`) library. The old version,` SDL1.2`, is no longer supported on many OS's, so this should allow more people to use this package if they like.

This works on my machine with the following specs:

### R
- R: 4.1.1
- RStudio: 1.4.1717

### C++ Compiler
- clang v12.0.0 (clang-1200.0.32.29)
- standard: gnu++14

### Machine
- MacOS Catalina v10.15.7
- Macbook Pro, Mid 2015 (Intel Processor, 64-bit)

## Notes
- To upgrade to `SDL2`, I followed the [official SDL2 migration guide](https://wiki.libsdl.org/SDL2/MigrationGuide), as well as a [super helpful thread](https://github.com/Jean-Romain/lidRviewer/issues/11) between @Jean-Romain and @silviculturalist. If you're still getting `SDL`-related errors, you may want to check out those threads for more context.
- I'm happy to answer questions or help others where I can. I know @Jean-Romain has stated that [this project is dormant](https://github.com/Jean-Romain/lidRviewer/issues/15#issuecomment-1423266882), and I'm hoping not to create a bunch more work for him on something he'd rather not maintain 😅 

